### PR TITLE
应用重启未能正确识别postgres及分页查询问题处理

### DIFF
--- a/comm/config.go
+++ b/comm/config.go
@@ -15,3 +15,7 @@ type Config struct {
 		Url    string `yaml:"url"`
 	} `yaml:"datasource"`
 }
+
+const DATASOURCE_DRIVER_MYSQL = "mysql"
+const DATASOURCE_DRIVER_POSTGRES = "postgres"
+const DATASOURCE_DRIVER_SQLITE = "sqlite"

--- a/comm/db.go
+++ b/comm/db.go
@@ -79,7 +79,7 @@ func FindPages(gen *bean.PageGen, ls interface{}, page int64, size ...int64) (*b
 	if gen.CountCols != "" {
 		counts = fmt.Sprintf("count(%s)", gen.CountCols)
 	}
-	sqls := strings.Replace(gen.SQL, "{{select}}", counts, 1)
+	sqls := strings.Replace(gen.SQL[:strings.LastIndex(gen.SQL,"\nORDER BY")], "{{select}}", counts, 1)
 	sqls = strings.Replace(sqls, "{{limit}}", "", 1)
 	_, err := Db.SQL(sqls, gen.Args...).Get(&count)
 	if err != nil {

--- a/migrates/up.go
+++ b/migrates/up.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gokins/gokins/comm"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/golang-migrate/migrate/v4/database/mysql"
+	"github.com/golang-migrate/migrate/v4/database/postgres"
 	"github.com/golang-migrate/migrate/v4/database/sqlite3"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
 	bindata "github.com/golang-migrate/migrate/v4/source/go_bindata"
@@ -53,6 +54,60 @@ func UpMysqlMigrate(ul string) error {
 	mgt, err := migrate.NewWithInstance(
 		"bindata", sc,
 		"mysql", driver)
+	if err != nil {
+		return err
+	}
+	defer mgt.Close()
+	err = mgt.Up()
+	if err != nil && err != migrate.ErrNoChange {
+		mgt.Down()
+		return err
+	}
+
+	return nil
+}
+
+func UpPostgresMigrate(ul string) error {
+	if ul == "" {
+		return errors.New("database config not found")
+	}
+	db, err := sql.Open("postgres", ul)
+	if err != nil {
+		//core.Log.Errorf("could not connect to postgres database... %v", err)
+		println("open db err:" + err.Error())
+		return err
+	}
+	err = db.Ping()
+	defer db.Close()
+	if err != nil {
+		return err
+	}
+
+	// Run migrations
+	driver, err := postgres.WithInstance(db, &postgres.Config{})
+	if err != nil {
+		println("could not start sql migration... ", err.Error())
+		return err
+	}
+	defer driver.Close()
+	var nms []string
+	tms := comm.AssetNames()
+	for _, v := range tms {
+		if strings.HasPrefix(v, "postgres") {
+			nms = append(nms, strings.Replace(v, "postgres/", "", 1))
+		}
+	}
+	s := bindata.Resource(nms, func(name string) ([]byte, error) {
+		return comm.Asset("postgres/" + name)
+	})
+	sc, err := bindata.WithInstance(s)
+	if err != nil {
+		return err
+	}
+	defer sc.Close()
+	mgt, err := migrate.NewWithInstance(
+		"bindata", sc,
+		"postgres", driver)
 	if err != nil {
 		return err
 	}

--- a/route/install.go
+++ b/route/install.go
@@ -87,7 +87,7 @@ func (InstallController) install(c *gin.Context, m *installConfig) {
 		c.String(500, "hbtp host err:%s", m.Server.HbtpHost)
 		return
 	}
-	if m.Datasource.Driver == "mysql" ||m.Datasource.Driver == "postgres" {
+	if m.Datasource.Driver == comm.DATASOURCE_DRIVER_MYSQL ||m.Datasource.Driver == comm.DATASOURCE_DRIVER_POSTGRES {
 		if !common.RegHost2.MatchString(m.Datasource.Host) {
 			c.String(500, "dbhost err:%s", m.Datasource.Host)
 			return

--- a/server/db.go
+++ b/server/db.go
@@ -15,16 +15,21 @@ import (
 
 func initDb() error {
 	var err error
-	dvs := "mysql"
+	dvs := comm.DATASOURCE_DRIVER_MYSQL
 	ul := comm.Cfg.Datasource.Url
 	if comm.Cfg.Datasource.Driver != "" {
 		dvs = comm.Cfg.Datasource.Driver
 	}
-	comm.IsMySQL = dvs == "mysql"
+	comm.IsMySQL = dvs == comm.DATASOURCE_DRIVER_MYSQL
 	if !comm.Installed {
-		if comm.IsMySQL {
+		switch dvs {
+		case comm.DATASOURCE_DRIVER_MYSQL:
 			err = migrates.UpMysqlMigrate(ul)
-		} else {
+			break
+		case comm.DATASOURCE_DRIVER_POSTGRES:
+			err = migrates.UpPostgresMigrate(ul)
+			break
+		default:
 			err = migrates.UpSqliteMigrate(ul)
 		}
 	}


### PR DESCRIPTION
1. 应用重启后，未能正确识别postgres
2. 分页查询中多余order by条件，导致sql错误